### PR TITLE
replace typescript-eslint-parser link to @typescript-eslint/parser

### DIFF
--- a/guide/30_other_parsers/README.ja.md
+++ b/guide/30_other_parsers/README.ja.md
@@ -20,7 +20,7 @@ const MyComponent = ({ onClick }: Props) => (
 覚えていますか？
 そうです、私達には https://astexplorer.net があります。
 
-TypeScript/JSXのパースを有効化するため、パーサー種別を "@eslint-typescript/parser" へ切り替えてください。
+TypeScript/JSXのパースを有効化するため、パーサー種別を "@typescript-eslint/parser" へ切り替えてください。
 
 ![switch_parser](./switch_parser.png)
 
@@ -57,7 +57,7 @@ export = rule;
 上記のルールをテストするため、このプロジェクトにパーサーを追加します。
 
 ```sh
-$ npm i @eslint-typescript/parser --dev
+$ npm i @typescript-eslint/parser --dev
 ```
 
 そして、ESLintのRuleTesterにパーサー設定をおこないます。
@@ -95,7 +95,7 @@ tester.run("no-jsx-button", rule, {
 ```
 
 どのような `parserOptions` が利用できるかは、各パーサーが決定します。
-たとえば、`@eslint-typescript/parser` の設定可能な値は [@typescript-eslint/parser configuration](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/parser#configuration) に列挙されています。
+たとえば、`@typescript-eslint/parser` の設定可能な値は [@typescript-eslint/parser configuration](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/parser#configuration) に列挙されています。
 また、 `parser` / `parserOptions` はチームのプロジェクトの .eslintrc ファイルにも存在しているはずです。
 
 もしも RuleTesterのパーサー設定を忘れてしまった場合、 `npm test` にて次のようなパースエラーが出力されてしまいます。

--- a/guide/30_other_parsers/README.ja.md
+++ b/guide/30_other_parsers/README.ja.md
@@ -73,20 +73,20 @@ import rule from "./no-jsx-button";
 const tester = new RuleTester({
   parser: "@typescript-eslint/parser",
   parserOptions: {
-    jsx: true,
+    ecmaFeatures: {
+      jsx: true,
+    },
   },
 });
 
 tester.run("no-jsx-button", rule, {
   valid: [
     {
-      filename: "valid.tsx", // filename must be set to tell parser this code is tsx
       code: `(props: props) => <div />`,
     },
   ],
   invalid: [
     {
-      filename: "invalid.tsx", // filename must be set to tell parser this code is tsx
       code: `(props: props) => <button />`,
       errors: [{ message: "don't use <button>" }],
     }
@@ -95,7 +95,7 @@ tester.run("no-jsx-button", rule, {
 ```
 
 どのような `parserOptions` が利用できるかは、各パーサーが決定します。
-たとえば、`@eslint-typescript/parser` の設定可能な値は https://github.com/eslint/typescript-eslint-parser に列挙されています。
+たとえば、`@eslint-typescript/parser` の設定可能な値は [@typescript-eslint/parser configuration](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/parser#configuration) に列挙されています。
 また、 `parser` / `parserOptions` はチームのプロジェクトの .eslintrc ファイルにも存在しているはずです。
 
 もしも RuleTesterのパーサー設定を忘れてしまった場合、 `npm test` にて次のようなパースエラーが出力されてしまいます。
@@ -105,9 +105,9 @@ Message:
   Should have no errors but had 1: [ { ruleId: null,
     fatal: true,
     severity: 2,
-    message: 'Parsing error: Unexpected token :',
+    message: "Parsing error: '>' expected.",
     line: 1,
-    column: 7 } ]
+    column: 23 } ]
 ```
 
 ## Summary

--- a/guide/30_other_parsers/README.md
+++ b/guide/30_other_parsers/README.md
@@ -73,20 +73,20 @@ import rule from "./no-jsx-button";
 const tester = new RuleTester({
   parser: "@typescript-eslint/parser",
   parserOptions: {
-    jsx: true,
+    ecmaFeatures: {
+      jsx: true,
+    },
   },
 });
 
 tester.run("no-jsx-button", rule, {
   valid: [
     {
-      filename: "valid.tsx", // filename must be set to tell parser this code is tsx
       code: `(props: Props) => <div />`,
     },
   ],
   invalid: [
     {
-      filename: "invalid.tsx", // filename must be set to tell parser this code is tsx
       code: `(props: Props) => <button />`,
       errors: [{ message: "Don't use <button>" }],
     }
@@ -95,8 +95,7 @@ tester.run("no-jsx-button", rule, {
 ```
 
 What value the `parserOptions` accepts is defined by each parser.
-For example, `@eslint-typescript/parser` 's configurable values are listed up in https://github.com/eslint/typescript-eslint-parser .
-The `parser` / `parserOptions` values also should exist at your team project's `.eslintrc`.
+For example, `@eslint-typescript/parser` 's configurable values are listed up in [@typescript-eslint/parser configuration](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/parser#configuration). The `parser` / `parserOptions` values also should exist at your team project's `.eslintrc`.
 
 If you forget to configure RuleTester's parser, `npm test` outputs parsing errors such as:
 
@@ -105,9 +104,9 @@ Message:
   Should have no errors but had 1: [ { ruleId: null,
     fatal: true,
     severity: 2,
-    message: 'Parsing error: Unexpected token :',
+    message: "Parsing error: '>' expected.",
     line: 1,
-    column: 7 } ]
+    column: 23 } ]
 ```
 
 ## Summary

--- a/guide/30_other_parsers/README.md
+++ b/guide/30_other_parsers/README.md
@@ -20,7 +20,7 @@ First of all, let's know AST structure for this.
 Do you remember?
 That's right, we have https://astexplorer.net
 
-To turn on TypeScript/JSX parsing, switch the parser type to "@eslint-typescript/parser".
+To turn on TypeScript/JSX parsing, switch the parser type to "@typescript-eslint/parser".
 
 ![switch_parser](./switch_parser.png)
 
@@ -57,7 +57,7 @@ export = rule;
 Next, we need to test the above rule so add parser to our project.
 
 ```sh
-$ npm i @eslint-typescript/parser --dev
+$ npm i @typescript-eslint/parser --dev
 ```
 
 And tell parser configuration to ESLint RuleTester.
@@ -95,7 +95,7 @@ tester.run("no-jsx-button", rule, {
 ```
 
 What value the `parserOptions` accepts is defined by each parser.
-For example, `@eslint-typescript/parser` 's configurable values are listed up in [@typescript-eslint/parser configuration](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/parser#configuration). The `parser` / `parserOptions` values also should exist at your team project's `.eslintrc`.
+For example, `@typescript-eslint/parser` 's configurable values are listed up in [@typescript-eslint/parser configuration](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/parser#configuration). The `parser` / `parserOptions` values also should exist at your team project's `.eslintrc`.
 
 If you forget to configure RuleTester's parser, `npm test` outputs parsing errors such as:
 


### PR DESCRIPTION
## Overview
I found `typescript-eslint-parser` repository has archived.
So I replaced the link to `@typescript-eslint/parser` and update guide contents.

The reason why update guide contents is `@typescript-eslint/parser`'s options changed from `typescript-eslint-parser`.

I have two way to fix the guide.
- The first idea is adding ecmaFeatures key to parserOptions and remove filename because it has been already unnecessary.
- The second idea is remove parserOptions because `ecmaFeatures.jsx` option detect file extension and change behavior.

I chose first idea because parserOptions explanation is very important to use parser.

## What I did
- replace the link of `typescript-eslint-parser` to `@typoescript-eslint/parser`
- update the guide contents
- fix typo `@eslint-typescript/parser`
