### PR TITLE
Update the description of the default parser

### DIFF
--- a/guide/30_other_parsers/README.ja.md
+++ b/guide/30_other_parsers/README.ja.md
@@ -24,7 +24,7 @@ TypeScript/JSX のパースを有効化するため、パーサー種別を "@ty
 
 ![switch_parser](./switch_parser.png)
 
-ちなみに、ESLint はデフォルトでは esprima というパーサーを使います。
+ちなみに、ESLint はデフォルトでは espree というパーサーを使います。
 
 `<button />` を見つけるクエリがわかりましたか？
 はい、 `JSXIdentifier[name='button']` ですね。

--- a/guide/30_other_parsers/README.md
+++ b/guide/30_other_parsers/README.md
@@ -24,7 +24,7 @@ To turn on TypeScript/JSX parsing, switch the parser type to "@typescript-eslint
 
 ![switch_parser](./switch_parser.png)
 
-FYI, ESLint uses esprima as default.
+FYI, ESLint uses espree as default.
 
 Can you get the query to find `<button />`?
 Yes, it's `JSXIdentifier[name='button']`.


### PR DESCRIPTION
Current [default parser of eslint](https://github.com/eslint/eslint/blob/e233920857e282ba22116ad5f1dcc6dfabc8ef5b/docs/user-guide/configuring/plugins.md#specifying-parser) is espree, so I updated the description.